### PR TITLE
Add documentation for configuration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,11 +124,11 @@ chameleon.create({
 
 ### Options as JS or JSON config file
 
-The above Javascript options can be persisted as either JS or a JSON configuration files. The files must be named chameleon.config.js or chameleon.config.json.
+The above Javascript options can be persisted as either JS or a JSON configuration file. The file must be named chameleon.config.js or chameleon.config.json.
 
-The tool automatically searches for configuration files in the directory where it was started and by going up in parent directories.
+The tool automatically searches for a configuration file in the directory where it was started and by going up in parent directories.
 
-Alternatively a `--config` flag with a path to the configuration file can be passed to the cli.
+Alternatively a `--config` option with a path to the configuration file can be passed to the cli.
 
 ### Command line options
 

--- a/README.md
+++ b/README.md
@@ -122,10 +122,19 @@ chameleon.create({
 });
 ```
 
+### Options as JS or JSON config file
+
+The above Javascript options can be persisted as either JS or a JSON configuration files. The files must be named chameleon.config.js or chameleon.config.json.
+
+The tool automatically searches for configuration files in the directory where it was started and by going up in parent directories.
+
+Alternatively a `--config' flag with a path to the configuration file can be passed to the cli.
+
 ### Command line options
 
 | option |  example | corresponding options property |
 |--|--|--|
+| `--config` | `--config=path/to/chameleon.config.js` |  |
 | `--path` | `--path=path/to/svg/directory/` | path |
 | `--subdir-name` | `--subdir-name=my-sprite-dir` | subdirName |
 | `--file-name` | `--file-name=my-sprite` | fileName |

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ The above Javascript options can be persisted as either JS or a JSON configurati
 
 The tool automatically searches for configuration files in the directory where it was started and by going up in parent directories.
 
-Alternatively a `--config' flag with a path to the configuration file can be passed to the cli.
+Alternatively a `--config` flag with a path to the configuration file can be passed to the cli.
 
 ### Command line options
 


### PR DESCRIPTION
I have adapted the documentation for the configuration files. 
Is that sufficient?

I was not sure where to place the --config option in the cli options.